### PR TITLE
PLANET-2863: Refine config for importing default content into UI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,9 @@ workflow_definitions:
       - run:
           name: Update nro-generator with the latest tag
           command: bash update_nro_generator.sh
-
+      - run:
+          name: Update UI Tests environment with the latest tag
+          command: bash update_ui_tests.sh
 
 workflows:
   version: 2
@@ -366,6 +368,7 @@ workflows:
         <<: *sync_common
         requires:
           - sync-sql-to-release
+
   create-default-sql:
     jobs:
     - create-default-sql:
@@ -375,5 +378,3 @@ workflows:
             ignore: /.*/
           tags:
             only: /v.*/
-
-

--- a/update_ui_tests.sh
+++ b/update_ui_tests.sh
@@ -1,0 +1,23 @@
+export PROJECT_UI_TESTS_PATH=/home/circleci/project/planet4-uitests/
+
+echo ""
+echo "Adding git user email and user name"
+echo ""
+git config --global user.email "circleci-bot@greenpeace.org"
+git config --global user.name "CircleCI Bot"
+git config --global push.default simple
+
+echo ""
+echo "Cloning the planet4-uitests repository"
+echo ""
+git clone https://github.com/greenpeace/planet4-uitests
+
+echo ""
+echo "Commiting release tag in the repository"
+echo ""
+git tag -a ${CIRCLE_TAG} -m "${CIRCLE_TAG} version of the sql to use"
+
+echo ""
+echo "Pushing changes"
+echo ""
+git -C ${PROJECT_UI_TESTS_PATH} push origin ${CIRCLE_TAG}


### PR DESCRIPTION
Hi! I'm starting this PR to have a place to track this conversation.

After some research and reading previous conversations, I'm thinking about this process:

- on tagged release pushed to `planet4-defaultcontent`:
  - run `planet4-defaultcontent/update_ui_tests.sh` to push the same release tag to `planet4-uitests`

And then:

- on tagged release pushed to `planet4-uitests`:
  - download content + db according to the tag
  - run a `test` job with some `run_backstop_tests.sh` script which goes:
    - if (no screenshots are found), run `generate_backstop_reference` (should only be valid for the first run)
    - run `backstop_test`
    - if (errors)
        - exit with error
    - else (success)
        - run `generate_backstop_reference` with the new release

The config for the `planet4-uitests` is still on the work, but I guess we would need something like:

```
  run_ui_tests: &run_ui_tests
    steps:
      - checkout
      - run: run_backstop_tests ${APP_HOME?}
      - run:
          name: Notify failure
          when: on_fail
          command: TYPE="Prepare" notify-job-failure.sh
      - store_artifacts:
          path: backstop_tests
          destination: artifacts
      - store_test_results:
          path: backstop_tests/ci
```

As for the rest of the config, I don't know which parts we want to keep, e.g.: holding to manually approve a release, etc.

Questions: 

- Do we need to Install `backstop` the same way `gulp` was installed? or can we defer that to a later point in the pipeline, maybe as a `planet4-uitests` job?:

ref: https://github.com/greenpeace/planet4-circleci/pull/12/files

- I'm not familiar with the filesystems here, so I'm not sure if the backstop images should be on GCloud, or 
CircleCI's `artifacts` or `workspace`...  

